### PR TITLE
feat: 공통 컴포넌트 스토리북 생성

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,17 +1,35 @@
-import type { StorybookConfig } from "@storybook/nextjs";
+import type { StorybookConfig } from '@storybook/nextjs';
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+import path from 'path';
+
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
   ],
   framework: {
-    name: "@storybook/nextjs",
+    name: '@storybook/nextjs',
     options: {},
   },
   docs: {
-    autodocs: "tag",
+    autodocs: 'tag',
+  },
+  webpackFinal: async (config: any) => {
+    // webpack svg loader 변경
+    const imageRule = config.module.rules.find(
+      (rule) => rule.test && rule.test.test('.svg')
+    );
+    imageRule.exclude = /\.svg$/;
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    });
+
+    // tsconfig path 설정
+    config.resolve.alias['@'] = path.resolve(__dirname, '../src/');
+    return config;
   },
 };
 export default config;

--- a/src/components/common/checkbox/CheckboxForm.stories.tsx
+++ b/src/components/common/checkbox/CheckboxForm.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import CheckboxForm from './CheckboxForm';
+import { CheckboxProps } from './type';
+
+const meta: Meta<typeof CheckboxForm> = {
+  title: '공통/CheckboxForm',
+  component: CheckboxForm,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '100%', padding: '20px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryFn<typeof CheckboxForm>;
+
+function Template(args: CheckboxProps) {
+  const { register } = useForm();
+  return <CheckboxForm {...args} formKey="check" register={register} />;
+}
+
+export const Primary: Story = Template.bind({});
+Primary.args = {
+  label: 'Checkbox',
+  formKey: 'checkbox',
+};

--- a/src/components/common/file/DragDrop.stories.tsx
+++ b/src/components/common/file/DragDrop.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DragDrop from './DragDrop';
+import { DragDropProps } from './type';
+
+const meta: Meta<typeof DragDrop> = {
+  title: '공통/DragDrop',
+  component: DragDrop,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryFn<typeof DragDrop>;
+
+function Template(args: DragDropProps) {
+  return <DragDrop {...args} onChange={() => {}} />;
+}
+
+export const Primary: Story = Template.bind({});
+Primary.args = {};

--- a/src/components/common/file/FileList.stories.tsx
+++ b/src/components/common/file/FileList.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import FileList from './FileList';
+import { FileListProps } from './type';
+
+const meta: Meta<typeof FileList> = {
+  title: '공통/FileList',
+  component: FileList,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: '10%',
+          height: '100%',
+          padding: '20px',
+          backgroundColor: '#f2f2f2',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryFn<typeof FileList>;
+
+function Template(args: FileListProps) {
+  return <FileList {...args} />;
+}
+
+export const Primary: Story = Template.bind({});
+Primary.args = {};

--- a/src/components/common/profile/ProfileButton.stories.tsx
+++ b/src/components/common/profile/ProfileButton.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import ProfileButton from './ProfileButton';
+
+const meta: Meta<typeof ProfileButton> = {
+  title: '공통/ProfileButton',
+  component: ProfileButton,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: '10%',
+          height: '100%',
+          padding: '20px',
+          backgroundColor: '#f2f2f2',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryFn<typeof ProfileButton>;
+
+function Template() {
+  return <ProfileButton />;
+}
+
+export const Primary: Story = Template.bind({});
+Primary.args = {};

--- a/src/components/common/textfield/TextField.stories.tsx
+++ b/src/components/common/textfield/TextField.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import TextField from './TextField';
+import { TextFieldProps } from './type';
+
+const meta: Meta<typeof TextField> = {
+  title: '공통/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryFn<typeof TextField>;
+
+function Template(args: TextFieldProps) {
+  const { register } = useForm();
+  return <TextField {...args} register={register} />;
+}
+
+export const Primary: Story = Template.bind({});
+Primary.args = {
+  label: 'TextField',
+  formKey: 'textfield',
+};


### PR DESCRIPTION
## Description
- 스토리북 설정 추가
- 공통 컴포넌트 스토리 생성

## Changes detail
-  스토리북 설정
  -  svg 로더 변경 => @svgr/webpack
  -  default path 변경 => @/   => ./src/  로 설정  (이래야 프로젝트 tsconfig.js. 파일의 디폴트 패쓰와 호환됨)
- 공통 컴포넌트 스토리 생성
 
## ScreenShot
- 드래그엔드랍
![image](https://user-images.githubusercontent.com/33804074/228544742-1479fb37-27cf-403d-8297-3cafffe2c59b.png)
- 파일리스트
![image](https://user-images.githubusercontent.com/33804074/228544897-6db83fd4-9fd9-42f7-b232-839d58974a5e.png)
- 프로필버튼
![image](https://user-images.githubusercontent.com/33804074/228544993-bdf90c05-3e39-4fdb-9001-451e92d499a6.png)
- 텍스트필드
![image](https://user-images.githubusercontent.com/33804074/228545077-501ae9ff-6f99-4105-8a1e-b57fa1c476aa.png)
- 체크박스 폼
![image](https://user-images.githubusercontent.com/33804074/228545291-d0f2066a-26d6-4d9e-ab9d-44bd17a415f2.png)

### Checklist

- [ ] Test case
- [ ] End of work
